### PR TITLE
Use random IDs for poll answers

### DIFF
--- a/src/events/PollStartEvent.ts
+++ b/src/events/PollStartEvent.ts
@@ -173,11 +173,11 @@ export class PollStartEvent extends ExtensibleEvent<M_POLL_START_EVENT_CONTENT> 
 
     /**
      * Creates a new PollStartEvent from question, answers, and metadata.
-     * @param {string} question The question to ask.
-     * @param {string} answers The answers. Should be unique within each other.
-     * @param {KNOWN_POLL_KIND|string} kind The kind of poll.
-     * @param {number} maxSelections The maximum number of selections. Must be 1 or higher.
-     * @returns {PollStartEvent} The representative poll start event.
+     * @param question The question to ask.
+     * @param answers The answers. Should be unique within each other.
+     * @param kind The kind of poll.
+     * @param maxSelections The maximum number of selections. Must be 1 or higher.
+     * @returns The representative poll start event.
      */
     public static from(question: string, answers: string[], kind: KNOWN_POLL_KIND | string, maxSelections = 1): PollStartEvent {
         return new PollStartEvent({
@@ -188,9 +188,16 @@ export class PollStartEvent extends ExtensibleEvent<M_POLL_START_EVENT_CONTENT> 
                     question: {[M_TEXT.name]: question},
                     kind: (kind instanceof NamespacedValue) ? kind.name : kind,
                     max_selections: maxSelections,
-                    answers: answers.map((a, i) => ({id: `${i + 1}-${a}`, [M_TEXT.name]: a})),
+                    answers: answers.map(a => ({id: makeId(), [M_TEXT.name]: a})),
                 },
             },
         });
     }
+}
+
+const LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+function makeId() {
+    return [...Array(16)].map(
+        () => LETTERS.charAt(Math.floor(Math.random() * LETTERS.length)),
+    ).join('');
 }

--- a/src/events/PollStartEvent.ts
+++ b/src/events/PollStartEvent.ts
@@ -173,11 +173,11 @@ export class PollStartEvent extends ExtensibleEvent<M_POLL_START_EVENT_CONTENT> 
 
     /**
      * Creates a new PollStartEvent from question, answers, and metadata.
-     * @param question The question to ask.
-     * @param answers The answers. Should be unique within each other.
-     * @param kind The kind of poll.
-     * @param maxSelections The maximum number of selections. Must be 1 or higher.
-     * @returns The representative poll start event.
+     * @param {string} question The question to ask.
+     * @param {string} answers The answers. Should be unique within each other.
+     * @param {KNOWN_POLL_KIND|string} kind The kind of poll.
+     * @param {number} maxSelections The maximum number of selections. Must be 1 or higher.
+     * @returns {PollStartEvent} The representative poll start event.
      */
     public static from(question: string, answers: string[], kind: KNOWN_POLL_KIND | string, maxSelections = 1): PollStartEvent {
         return new PollStartEvent({

--- a/test/events/PollStartEvent.test.ts
+++ b/test/events/PollStartEvent.test.ts
@@ -280,9 +280,17 @@ describe('PollStartEvent', () => {
             expect(M_POLL_KIND_DISCLOSED.matches(poll.rawKind)).toBe(true);
             expect(poll.maxSelections).toBe(2);
             expect(poll.answers.length).toBe(3);
-            expect(poll.answers.some(a => a.id === "1-A" && a.text === "A")).toBe(true);
-            expect(poll.answers.some(a => a.id === "2-B" && a.text === "B")).toBe(true);
-            expect(poll.answers.some(a => a.id === "3-C" && a.text === "C")).toBe(true);
+            expect(poll.answers.some(a => a.text === "A")).toBe(true);
+            expect(poll.answers.some(a => a.text === "B")).toBe(true);
+            expect(poll.answers.some(a => a.text === "C")).toBe(true);
+
+            // Ids are non-empty and unique
+            expect(poll.answers[0].id).toHaveLength(16);
+            expect(poll.answers[1].id).toHaveLength(16);
+            expect(poll.answers[2].id).toHaveLength(16);
+            expect(poll.answers[0].id).not.toEqual(poll.answers[1].id);
+            expect(poll.answers[0].id).not.toEqual(poll.answers[2].id);
+            expect(poll.answers[1].id).not.toEqual(poll.answers[2].id);
 
             const serialized = poll.serialize();
             expect(M_POLL_START.matches(serialized.type)).toBe(true);
@@ -296,9 +304,9 @@ describe('PollStartEvent', () => {
                     max_selections: 2,
                     answers: [
                         // M_TEXT tested by MessageEvent tests
-                        {id: "1-A", [M_TEXT.name]: expect.any(String)},
-                        {id: "2-B", [M_TEXT.name]: expect.any(String)},
-                        {id: "3-C", [M_TEXT.name]: expect.any(String)},
+                        {id: expect.any(String), [M_TEXT.name]: expect.any(String)},
+                        {id: expect.any(String), [M_TEXT.name]: expect.any(String)},
+                        {id: expect.any(String), [M_TEXT.name]: expect.any(String)},
                     ],
                 },
             });
@@ -311,9 +319,9 @@ describe('PollStartEvent', () => {
             expect(poll.rawKind).toBe("org.example.poll.kind");
             expect(poll.maxSelections).toBe(2);
             expect(poll.answers.length).toBe(3);
-            expect(poll.answers.some(a => a.id === "1-A" && a.text === "A")).toBe(true);
-            expect(poll.answers.some(a => a.id === "2-B" && a.text === "B")).toBe(true);
-            expect(poll.answers.some(a => a.id === "3-C" && a.text === "C")).toBe(true);
+            expect(poll.answers.some(a => a.text === "A")).toBe(true);
+            expect(poll.answers.some(a => a.text === "B")).toBe(true);
+            expect(poll.answers.some(a => a.text === "C")).toBe(true);
 
             const serialized = poll.serialize();
             expect(M_POLL_START.matches(serialized.type)).toBe(true);
@@ -327,9 +335,9 @@ describe('PollStartEvent', () => {
                     max_selections: 2,
                     answers: [
                         // M_MESSAGE tested by MessageEvent tests
-                        {id: "1-A", [M_TEXT.name]: expect.any(String)},
-                        {id: "2-B", [M_TEXT.name]: expect.any(String)},
-                        {id: "3-C", [M_TEXT.name]: expect.any(String)},
+                        {id: expect.any(String), [M_TEXT.name]: expect.any(String)},
+                        {id: expect.any(String), [M_TEXT.name]: expect.any(String)},
+                        {id: expect.any(String), [M_TEXT.name]: expect.any(String)},
                     ],
                 },
             });


### PR DESCRIPTION
As part of work on editing polls, I need new answers to get different IDs from the old ones, so that any votes that sneaked in before the poll was edited will be ignored.

The more I thought about it, the more I thought that using the answer in the ID was a bad idea anyway, since they can potentially be long and contain weird characters etc.

So, this change generates random IDs when you create a PollStartEvent.

I didn't want to add a dependency on a UUID library or similar, so I generate random strings, which should be more than sufficient to ensure all answers within a poll receive unique IDs, and that an edited poll's answers do not clash with the before-edited ones.